### PR TITLE
registry: add 'ods' in file types

### DIFF
--- a/registry/registry.py
+++ b/registry/registry.py
@@ -107,6 +107,7 @@ def get_file_type(file_type):
         'csv': 'CSV',
         'json': 'json',
         'xlsx': 'Excel',
+        'ods': 'ODS',
     }
     return file_types.get(file_type, 'file')
 


### PR DESCRIPTION
closes #64 

Front end was already considering `ods` files.
https://github.com/ThreeSixtyGiving/registry/blob/master/registry/templates/registry.html#L102
