### PR TITLE
Remove extra s from badge

### DIFF
--- a/registry-vue/src/components/publishers/data/badges.js
+++ b/registry-vue/src/components/publishers/data/badges.js
@@ -32,7 +32,7 @@ const badges = [
   {
     qualityMetric: 'has50pcExternalOrgId',
     iconName: 'confirmation_number',
-    label: 'Includess over 50% external org IDs'
+    label: 'Includes over 50% external org IDs'
   },
   {
     qualityMetric: 'publishedThisYear',


### PR DESCRIPTION
Correction to "Includess over 50% external org IDs" badge