### PR TITLE
Updating link from Data Registry to JSON feed

### DIFF
--- a/registry/templates/registry.html
+++ b/registry/templates/registry.html
@@ -18,7 +18,7 @@
       </div>
         <p>
           Looking to build tools or do research with the data?
-          <a href="http://standard.threesixtygiving.org/en/latest/getdata/#registry" target="_blank">Use our JSON feed</a>.
+          <a href="https://www.threesixtygiving.org/data/using-360giving-data/#Registry_feed" target="_blank">Use our JSON feed</a>.
         </p>
         <p>
           Want to publish your grants data openly with the 360Giving standard? Visit our


### PR DESCRIPTION
The current link directs to a page in Standard docs which has since been changed. The new link directs to the part of page on 360Giving website about the Registry JSON.